### PR TITLE
Increase default kernel ridge value to ensure positive-definite kerne…

### DIFF
--- a/neural_testbed/generative/gp_regression_envlikelihood.py
+++ b/neural_testbed/generative/gp_regression_envlikelihood.py
@@ -36,7 +36,7 @@ class GPRegressionEnvLikelihood(likelihood.GenerativeDataSampler):
                key: chex.PRNGKey,
                tau: int = 1,
                noise_std: float = 1,
-               kernel_ridge: float = 1e-6,
+               kernel_ridge: float = 1e-5,
                ntk: bool = False):
 
     # Checking the dimensionality of our data coming in.


### PR DESCRIPTION
I was looking at the univariate regression problems implemented in the package, and I realized that the [kernel_ridge default value](https://github.com/deepmind/neural_testbed/blob/47c67af4f3777f59084bdfba739af7065245d395/neural_testbed/generative/gp_regression_envlikelihood.py#L39) is not sufficiently high to ensure that the kernel matrix is positive-definite. So all the univariate regression problems in the leaderboard (0-89) have nans in the target variables.

Increasing it a default value of 1e-5 solves the issue.